### PR TITLE
comments on nmmso iteration

### DIFF
--- a/pynmmso/swarm.py
+++ b/pynmmso/swarm.py
@@ -198,7 +198,7 @@ class Swarm:
         float
             The distance between the two swarms.
         """
-        return np.linalg.norm(self.mode_location - swarm.mode_location)
+        return np.linalg.norm(self.mode_location - swarm.mode_location)  # param dist
 
     def merge(self, swarm):
         """


### PR DESCRIPTION
Here's what I had seen about crossover probabilities in deap, where it is a parameter to the uniform crossover function [here](https://github.com/DEAP/deap/blob/ed7f04d330880839c11e4e624566c9fa616181bb/deap/tools/crossover.py#L79).
And alternatives are one-point or two-point, where only 1 or 2 places are swapped

the probability may for example, be set to 0.1:
```bash
examples/ga/evoknn_jmlr.py:32     toolbox.register("mate", tools.cxUniform, indpb=0.1)
examples/ga/evoknn.py:66          toolbox.register("mate", tools.cxUniform, indpb=0.1)
```

